### PR TITLE
Fixed url error

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 
                                 <li>
                                   <a href="files/useR-2016-flyer.pdf"><i class=
-                                    "icon-th-list"></i> Conference flyer</a>
+                                    "icon-arrow-down"></i> Conference flyer</a>
                                 </li>
 
 				<!-- <li class="divider"></li>
@@ -149,7 +149,7 @@
 		      <p>
 			<i>We have had some requests for a flyer. The
 			  flyer is now available online as
-			  a <a href="files/user-2016-flyer.pdf">pdf</a>
+			  a <a href="files/useR-2016-flyer.pdf">pdf</a>
 			  via the link at right.
 			</i>
 		      </p>


### PR DESCRIPTION
Fixed typo in link to flyer pdf

Hi Karthik,
I fixed a typo that was pointing to a non-existent pdf.  But I still find that the “conference flyer” link on the right menu doesn’t work. Can you fix that? Thanks.
-N
